### PR TITLE
Update client to use new CSL API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gem Version](https://badge.fury.io/rb/import_export.svg)](https://badge.fury.io/rb/import_export) [![Build Status](https://travis-ci.org/benbalter/import_export.svg)](https://travis-ci.org/benbalter/import_export)
 
-A Ruby client for [Trade.gov's Consolidated Screening List](https://developer.trade.gov/consolidated-screening-list.html)
+A Ruby client for [Trade.gov's Consolidated Screening List](https://developer.trade.gov/api-details#api=consolidated-screening-list).
 
 ## Usage
 
@@ -38,7 +38,7 @@ NOTE: `api_key` defaults to `ENV["TRADE_API_KEY"]` if not specified.
 * `size` (number of results per page, defaults to 100)
 * `offset` (defaults to 0)
 
-For more information, see [the Consolidated Screening List API docs](https://developer.trade.gov/consolidated-screening-list.html).
+For more information, see [the Consolidated Screening List API docs](https://developer.trade.gov/api-details#api=consolidated-screening-list).
 
 ### Command line usage
 
@@ -48,7 +48,7 @@ import_export [NAME]
 
 ## Contributing
 
-1. Fork it ( https://github.com/[my-github-username]/consolidated_screening_list/fork )
+1. Fork it (https://github.com/[my-github-username]/consolidated_screening_list/fork)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/lib/import_export.rb
+++ b/lib/import_export.rb
@@ -15,10 +15,10 @@ require 'import_export/client'
 require 'import_export/query'
 
 Dotenv.load
-RestClient.log = STDOUT unless ENV['DEBUG'].to_s.empty?
+RestClient.log = $stdout unless ENV['DEBUG'].to_s.empty?
 
 module ImportExport
-  API_BASE = 'https://api.trade.gov/gateway/v1/consolidated_screening_list/'
+  API_BASE = 'https://data.trade.gov/consolidated_screening_list/v1/'
 
   def self.user_agent
     "ImportExport/#{ImportExport::VERSION}; +https://github.com/benbalter/import_export)"

--- a/lib/import_export/query.rb
+++ b/lib/import_export/query.rb
@@ -55,12 +55,14 @@ module ImportExport
     def call
       RestClient.get Query.endpoint, {
         :params => params,
-        'Authorization' => "Bearer #{@api_key}",
+        'subscription-key' => api_key,
         'User-Agent' => ImportExport.user_agent
       }
     end
 
     private
+
+    attr_reader :api_key
 
     def params
       params = @params.clone

--- a/lib/import_export/version.rb
+++ b/lib/import_export/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ImportExport
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/import_export_client_spec.rb
+++ b/spec/import_export_client_spec.rb
@@ -15,7 +15,7 @@ describe ImportExport::Client do
   end
 
   it 'calls the API' do
-    stub = stub_request(:get, %r{https://api\.trade\.gov/gateway/v1/consolidated_screening_list/search.*})
+    stub = stub_request(:get, %r{https://data\.trade\.gov/consolidated_screening_list/v1/search.*})
            .to_return(status: 200, body: '{"results": [{"foo": "bar"}, {"foo2": "bar2"}]}')
 
     with_env 'TRADE_API_KEY', 'd77f752c-9769-41ad-b2ac-267b5779353a' do

--- a/spec/import_export_query_spec.rb
+++ b/spec/import_export_query_spec.rb
@@ -11,7 +11,7 @@ describe ImportExport::Query do
   end
 
   it 'builds the endpoint' do
-    expected = 'https://api.trade.gov/gateway/v1/consolidated_screening_list/search'
+    expected = 'https://data.trade.gov/consolidated_screening_list/v1/search'
     expect(described_class.endpoint).to eql(expected)
   end
 
@@ -29,8 +29,8 @@ describe ImportExport::Query do
   end
 
   it 'builds the param lists' do
-    expect(subject.send(:params)[:countries]).to match(/AF\,AX/)
-    expect(subject.send(:params)[:sources]).to match(/CAP\,DPL/)
+    expect(subject.send(:params)[:countries]).to match(/AF,AX/)
+    expect(subject.send(:params)[:sources]).to match(/CAP,DPL/)
   end
 
   it 'strips empty params' do
@@ -40,7 +40,7 @@ describe ImportExport::Query do
 
   it 'calls the API' do
     json = '{"results": [{"foo": "bar"}]}'
-    stub = stub_request(:get, %r{https://api\.trade\.gov/gateway/v1/consolidated_screening_list/search.*})
+    stub = stub_request(:get, %r{https://data\.trade\.gov/consolidated_screening_list/v1/search.*})
            .to_return(status: 200, body: json)
 
     expect(subject.call).to eql(json)


### PR DESCRIPTION
CSL API has changed to a new endpoint and a slightly different authorization method. Legacy API will be sunset on December 6, 2021.

https://developer.trade.gov/csl-api-is-changing