### PR TITLE
Adds types query parameter

### DIFF
--- a/lib/import_export/query.rb
+++ b/lib/import_export/query.rb
@@ -19,7 +19,7 @@ module ImportExport
       address: nil,
       name: nil,
       fuzzy_name: false,
-      type: nil,
+      types: nil,
       size: 100,
       offset: 0
     }.freeze

--- a/lib/import_export/query.rb
+++ b/lib/import_export/query.rb
@@ -19,6 +19,7 @@ module ImportExport
       address: nil,
       name: nil,
       fuzzy_name: false,
+      type: nil,
       types: nil,
       size: 100,
       offset: 0


### PR DESCRIPTION
It appears that ITA updated their parameters for query to use types rather than type. This has led to a 15% increase in results with the wrong entity being presented to our analysts causing additional work. Correcting this should improve the efficiency of our VRM team.