### PR TITLE
Add method to return the "total" field from the original API response

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ NOTE: `api_key` defaults to `ENV["TRADE_API_KEY"]` if not specified.
 * `name`
 * `fuzzy_name` (true or false)
 * `type`
-* `size` (number of results per page, defaults to 100)
+* `size` (number of results per page, defaults to 50)
 * `offset` (defaults to 0)
 
 For more information, see [the Consolidated Screening List API docs](https://developer.trade.gov/api-details#api=consolidated-screening-list).

--- a/lib/import_export/client.rb
+++ b/lib/import_export/client.rb
@@ -20,6 +20,11 @@ module ImportExport
       parse_response Query.new(params, api_key).call
     end
 
+    def overall_total(params = {})
+      response = Query.new(params, api_key).call
+      JSON.parse(response)['total']
+    end
+
     private
 
     def parse_response(response)

--- a/lib/import_export/client.rb
+++ b/lib/import_export/client.rb
@@ -20,15 +20,17 @@ module ImportExport
       parse_response Query.new(params, api_key).call
     end
 
-    def overall_total(params = {})
-      response = Query.new(params, api_key).call
-      JSON.parse(response)['total']
-    end
-
     private
 
     def parse_response(response)
-      JSON.parse(response)['results'].map { |data| Result.new(data) }
+      payload = JSON.parse(response)
+      ResultsArray.new(payload['results'].map { |data| Result.new(data) }).tap do |results|
+        results.total_results = payload['total']
+      end
     end
+  end
+
+  class ResultsArray < Array
+    attr_accessor :total_results
   end
 end

--- a/lib/import_export/query.rb
+++ b/lib/import_export/query.rb
@@ -21,7 +21,7 @@ module ImportExport
       fuzzy_name: false,
       type: nil,
       types: nil,
-      size: 100,
+      size: 50,
       offset: 0
     }.freeze
 

--- a/lib/import_export/query.rb
+++ b/lib/import_export/query.rb
@@ -51,6 +51,10 @@ module ImportExport
       if invalid = !UUID.validate(api_key)
         raise ArgumentError, "Invalid API key: #{invalid}"
       end
+
+      if invalid = @params[:size].to_i > 50
+        raise ArgumentError, "API only accepts maximum size param of 50"
+      end
     end
 
     def call
@@ -67,6 +71,7 @@ module ImportExport
 
     def params
       params = @params.clone
+
       params[:countries] = params[:countries].join(',')
       params[:sources]   = params[:sources].join(',')
       params.reject { |_k, v| v.nil? }

--- a/lib/import_export/query.rb
+++ b/lib/import_export/query.rb
@@ -71,7 +71,6 @@ module ImportExport
 
     def params
       params = @params.clone
-
       params[:countries] = params[:countries].join(',')
       params[:sources]   = params[:sources].join(',')
       params.reject { |_k, v| v.nil? }

--- a/spec/import_export_client_spec.rb
+++ b/spec/import_export_client_spec.rb
@@ -27,4 +27,31 @@ describe ImportExport::Client do
       expect(search.first.foo).to eql('bar')
     end
   end
+
+  describe '#overall_total' do
+    let(:expected_total) { 2 }
+    it 'returns the total possible results for a query' do
+      stub = stub_request(:get, %r{https://data\.trade\.gov/consolidated_screening_list/v1/search.*})
+            .to_return(status: 200, body: "{\"total\": #{expected_total}, \"results\": [{\"foo\": \"bar\"}, {\"foo2\": \"bar2\"}]}")
+
+      with_env 'TRADE_API_KEY', 'd77f752c-9769-41ad-b2ac-267b5779353a' do
+        total = subject.overall_total q: 'smith'
+        expect(stub).to have_been_requested
+
+        expect(total).to be(expected_total)
+      end
+    end
+
+    it 'returns the total possible results for a query regardless of other params' do
+      stub = stub_request(:get, %r{https://data\.trade\.gov/consolidated_screening_list/v1/search.*})
+            .to_return(status: 200, body: "{\"total\": #{expected_total}, \"results\": [{\"foo\": \"bar\"}, {\"foo2\": \"bar2\"}]}")
+
+      with_env 'TRADE_API_KEY', 'd77f752c-9769-41ad-b2ac-267b5779353a' do
+        total = subject.overall_total(q: 'smith', size: 1)
+        expect(stub).to have_been_requested
+
+        expect(total).to be(expected_total)
+      end
+    end
+  end
 end

--- a/spec/import_export_client_spec.rb
+++ b/spec/import_export_client_spec.rb
@@ -28,17 +28,18 @@ describe ImportExport::Client do
     end
   end
 
-  describe '#overall_total' do
+  describe '#total_results' do
     let(:expected_total) { 2 }
+
     it 'returns the total possible results for a query' do
       stub = stub_request(:get, %r{https://data\.trade\.gov/consolidated_screening_list/v1/search.*})
             .to_return(status: 200, body: "{\"total\": #{expected_total}, \"results\": [{\"foo\": \"bar\"}, {\"foo2\": \"bar2\"}]}")
 
       with_env 'TRADE_API_KEY', 'd77f752c-9769-41ad-b2ac-267b5779353a' do
-        total = subject.overall_total q: 'smith'
+        search = subject.search q: 'smith'
         expect(stub).to have_been_requested
 
-        expect(total).to be(expected_total)
+        expect(search.total_results).to be(expected_total)
       end
     end
 
@@ -47,10 +48,10 @@ describe ImportExport::Client do
             .to_return(status: 200, body: "{\"total\": #{expected_total}, \"results\": [{\"foo\": \"bar\"}, {\"foo2\": \"bar2\"}]}")
 
       with_env 'TRADE_API_KEY', 'd77f752c-9769-41ad-b2ac-267b5779353a' do
-        total = subject.overall_total(q: 'smith', size: 1)
+        search = subject.search(q: 'smith', size: 1)
         expect(stub).to have_been_requested
 
-        expect(total).to be(expected_total)
+        expect(search.total_results).to be(expected_total)
       end
     end
   end


### PR DESCRIPTION
* Fixes a bug where the FTC API doesn't accept param `size` greater than 50 and instead returns 10 results no matter what is requested (see screenshots). [Their api docs ](https://developer.trade.gov/api-details?_gl=1*16tf1b6*_ga*MjM3NjkxNzA3LjE3NDIzOTEzOTc.*_ga_L884J52XQ5*MTc0NDIzMjYxNS40LjAuMTc0NDIzMjYxOS41Ni4wLjA.*_ga_6D3N6M4S6H*MTc0NDIzMjYxNS40LjAuMTc0NDIzMjYxNS4wLjAuMA..#api=consolidated-screening-list&operation=search)do reference the 50 max but not the 10 behavior.
![Screenshot 2025-04-08 at 4 33 42 PM](https://github.com/user-attachments/assets/481cb5b8-86f7-40ca-acf4-67b8f862ee47)
![Screenshot 2025-04-08 at 4 33 56 PM](https://github.com/user-attachments/assets/4062146e-d9ae-4b87-bc33-a99228a12b36)

* Adds a method for total_results that retrieves the expected number of results for the param. This will allow callers to manage pagination and better use the `size` and `offset` params (alternately, you can issue requests until you get an empty array, but it would be helpful to know if that could be excessive, see example below)
![Screenshot 2025-04-08 at 4 33 42 PM](https://github.com/user-attachments/assets/97bdbe28-c5ae-4c8b-a93f-61e401884276)

