### PR TITLE
Loosen dotenv gem dependency to allow v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 mkmf.log
 .env
 *.gem
+/vendor/

--- a/import_export.gemspec
+++ b/import_export.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'dotenv', '~> 2.7'
+  spec.add_dependency 'dotenv', '>= 2.7', '< 4.0'
   spec.add_dependency 'iso_country_codes', '~> 0.7'
   spec.add_dependency 'rest-client', '~> 2.1'
   spec.add_dependency 'uuid', '~> 2.3'

--- a/lib/import_export/source.rb
+++ b/lib/import_export/source.rb
@@ -14,7 +14,7 @@ module ImportExport
       'SDN' => 'Specially Designated Nationals',
       'SSI' => 'Sectoral Sanctions Identifications List',
       'UVL' => 'Unverified List',
-      '561' => 'Part 561 List'
+      '561' => 'Part 561 List',
     }.freeze
 
     class << self

--- a/lib/import_export/version.rb
+++ b/lib/import_export/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ImportExport
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
* Allows for `dotenv` upgrade to 3.x